### PR TITLE
delete `draft: true` from course specific template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: USGSmarkdowntemplates
 Type: Package
 Title: Alternate R Markdown Templates
-Version: 0.0.8
-Date: 2017-03-29
+Version: 0.0.9
+Date: 2017-04-06
 Author: Bob Rudis (@hrbrmstr), Kieran Healy <kjhealy@gmail.com>
 Maintainer: Bob Rudis <bob@rudis.net>
 Description: A set of alternate R markdown templates that do not

--- a/inst/rmarkdown/templates/hugoTraining_course/resources/default.md
+++ b/inst/rmarkdown/templates/hugoTraining_course/resources/default.md
@@ -2,7 +2,6 @@
 date: $if(date)$$date$$endif$
 slug: $if(slug)$$slug$$endif$
 title: $if(title)$$title$$endif$
-draft: True
 menu:
   main:
     parent: $if(parent)$$parent$$endif$


### PR DESCRIPTION
Kept `draft: true` in regular course template, but removed it from the one that pertains to course specific docs.

@ldecicco-USGS please review + merge